### PR TITLE
Added link for FOTF Toolbox in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Convert the identified model to this format:
 
 Then we can get the parameter k and tau.
 
-## FOTF toolbox
+## FOTF Toolbox
+https://www.mathworks.com/matlabcentral/fileexchange/60874-fotf-toolbox
 
 ## Oustaloup
 
 # 3. Downloading FOPD-tunner library and run examples
-##Clone the repository:
+## Clone the repository:
 ```
 git clone https://github.com/cnpcshangbo/FOPD-tunner.git
 ```


### PR DESCRIPTION
The toolbox is used when plotting Bode plot for the FOPD controller.